### PR TITLE
 Replaces deprecated maven plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ file used in the Android client.
 ## Build and deploy
 - To build and run the backend module locally:
 ```bash
-% mvn clean gcloud:run
+% mvn clean appengine:run
 ```
 
 - To deploy the backend module to App Engine:
 ```bash
-% mvn gcloud:deploy
+% mvn appengine:deploy
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ file used in the Android client.
 ## Build and deploy
 - To build and run the backend module locally:
 ```bash
-% mvn clean appengine:run
+% mvn clean package appengine:run
 ```
 
 - To deploy the backend module to App Engine:
 ```bash
-% mvn appengine:deploy
+% mvn clean package appengine:deploy
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,10 @@
           </webResources>
         </configuration>
       </plugin>
-
       <plugin>
-        <groupId>com.google.appengine</groupId>
-        <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.90.v20151210</version>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>appengine-maven-plugin</artifactId>
+        <version>1.3.2</version>
         <configuration>
           <promote>true</promote>
         </configuration>


### PR DESCRIPTION
* Replaced the deprecated gcloud-maven-plugin with appengine-maven-plugin.
* Updated README with instructions on how to run and deploy the app using the following commands:
    ```
    mvn clean package appengine:run
    mvn clean package appengine:deploy
    ```

Tested with [firebase-android-client](https://github.com/GoogleCloudPlatform/firebase-android-client) app. 