### PR TITLE
Changes the default logging level to INFO.

### DIFF
--- a/src/main/webapp/WEB-INF/logging.properties
+++ b/src/main/webapp/WEB-INF/logging.properties
@@ -9,5 +9,5 @@
 # </system-properties>
 #
 
-# Set the default logging level for all loggers to WARNING
-.level = ALL
+# Set the default logging level for all loggers to INFO
+.level = INFO


### PR DESCRIPTION
The previous logging level (`ALL`) displays the following message in the console when there's a request to `http://localhost:8080/printLogs`:

```
[INFO] GCLOUD: FINEST: Ignoring Exception getting module instance and continuing
[INFO] GCLOUD: com.google.appengine.api.modules.ModulesException: Instance id unavailable
```

The exception is expected and doesn't indicate any problems according to https://issuetracker.google.com/35896861.

However, the message can be confusing to developers that run the code sample in this repository. Changing the default logging level to `INFO` removes the error message from the console.