### PR TITLE
Adds note about instrument error when running locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ To build and run the backend module locally:
 mvn clean package appengine:run
 ```
 
+> **Note:** If you run into the following error with the previous command:
+>   ```
+>   agent library failed to init: instrument
+>   ```
+>   Update Google Cloud SDK to version `240`:
+>   ```
+>   gcloud components update --version 240.0.0
+>   ```
+
 To deploy the backend module to App Engine:
 
 ```bash


### PR DESCRIPTION
As explained in #21, deploying this code sample locally fails with the following error:

```
GCLOUD: agent library failed to init: instrument
```

There is a [related bug][0] filed on the Google Cloud SDK buganizer.

This PR adds a note to let developers know that they should use gcloud version `240` to run this sample.

[0]: https://issuetracker.google.com/130169015