### PR TITLE
Remove workaround to run app locally

### DIFF
--- a/.kokoro/continuous.sh
+++ b/.kokoro/continuous.sh
@@ -17,9 +17,7 @@
 set -e
 
 # Update gcloud and check version
-echo "Updating specifically to version 240.0.0 to workaround an issue in the " \
-     "Cloud SDK"
-gcloud components update --version 240.0.0
+gcloud components update --quiet
 echo "********** GCLOUD INFO ***********"
 gcloud -v
 echo "********** MAVEN INFO  ***********"

--- a/.kokoro/periodic.sh
+++ b/.kokoro/periodic.sh
@@ -17,9 +17,7 @@
 set -e
 
 # Update gcloud and check version
-echo "Updating specifically to version 240.0.0 to workaround an issue in the " \
-     "Cloud SDK"
-gcloud components update --version 240.0.0
+gcloud components update --quiet
 echo "********** GCLOUD INFO ***********"
 gcloud -v
 echo "********** MAVEN INFO  ***********"

--- a/.kokoro/presubmit.sh
+++ b/.kokoro/presubmit.sh
@@ -17,9 +17,7 @@
 set -e
 
 # Update gcloud and check version
-echo "Updating specifically to version 240.0.0 to workaround an issue in the " \
-     "Cloud SDK"
-gcloud components update --version 240.0.0
+gcloud components update --quiet
 echo "********** GCLOUD INFO ***********"
 gcloud -v
 echo "********** MAVEN INFO  ***********"

--- a/README.md
+++ b/README.md
@@ -103,15 +103,6 @@ To build and run the backend module locally:
 mvn clean package appengine:run
 ```
 
-> **Note:** If you run into the following error with the previous command:
->   ```
->   agent library failed to init: instrument
->   ```
->   Update Google Cloud SDK to version `240`:
->   ```
->   gcloud components update --version 240.0.0
->   ```
-
 To deploy the backend module to App Engine:
 
 ```bash

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -29,4 +29,5 @@
     <resource-files>
         <include path="/**.json" />
     </resource-files>
+    <runtime>java8</runtime>
 </appengine-web-app>


### PR DESCRIPTION
The [`appengine-web.xml`][1] file needs the [`runtime`][0] element.



This fixes #21.

[0]: https://cloud.google.com/appengine/docs/standard/java/config/appref#runtime
[1]: /firebase-appengine-backend/blob/master/src/main/webapp/WEB-INF/appengine-web.xml