### PR TITLE
Update App Engine Maven plugin to version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.3.2</version>
+        <version>2.2.0</version>
         <configuration>
           <promote>true</promote>
         </configuration>


### PR DESCRIPTION
The [Google App Engine Maven plugin][0] is currently on version `2.2.0`.

This fixes #20.

[0]: /GoogleCloudPlatform/app-maven-plugin